### PR TITLE
Replace all with -1 to allow all kind of inbound traffic.

### DIFF
--- a/LAMP/ops/terraform/lamp.tf
+++ b/LAMP/ops/terraform/lamp.tf
@@ -21,7 +21,7 @@ resource "aws_security_group" "allow_all" {
   ingress {
       from_port = 0
       to_port = 65535
-      protocol = "all"
+      protocol = "-1"
       cidr_blocks = ["0.0.0.0/0"]
   }
 }


### PR DESCRIPTION
AWS doesn't support `all` as a protocol, to allow all kind of inbound traffic the protocol code is `-1` 
ref: https://github.com/hashicorp/terraform/pull/1101/files

@KFishner  r ?