### PR TITLE
Added example to deploy Discourse on AWS

### DIFF
--- a/Discourse/README.md
+++ b/Discourse/README.md
@@ -1,0 +1,128 @@
+Setup Discourse on AWS
+===
+This repository and walkthrough guides you through deploying Discourse forum on AWS using officially supported Docker installation. More details on the docker image installation method can be found in [Discourse install guide](https://github.com/discourse/discourse/blob/master/docs/INSTALL.md)
+
+General setup
+-------------
+1. Clone this repository
+2. Create an Atlas account
+3. Generate an [Atlas token](https://atlas.hashicorp.com/settings/tokens) and save as an environment variable. 
+`export ATLAS_TOKEN=<your_token>`
+4. In the Packer and Terraform files `ops/discourse-artifact.json` and `ops/terraform/discourse-infra.tf` you need to replace all instances of `<username>`,  `YOUR_ATLAS_TOKEN`, `YOUR_SECRET_HERE`, and `YOUR_KEY_HERE` with your Atlas username, Atlas token, and AWS keys.
+
+Introduction and Configuring Discourse
+---
+The only officially supported installs of Discourse are the Docker based installs. In this guide we will deploy Discourse forum on a `t2.micro` instance of AWS. For a 1 GB install it's advised to create a swap file but if you're using 2 GB+ memory, you can probably get by without a swap file. The `ops/scripts/create_swap.sh` creates a swap file and `ops/scripts/deploy.sh` deploys, bootstraps and starts the Discourse application. Discourse configuration is stored in `ops/configs/standalone.yml`.
+
+Step 1: Edit Discourse Configuration
+---
+Edit the Discourse configuration at `ops/configs/standalone.yml`.
+
+- Set `DISCOURSE_DEVELOPER_EMAILS` to your email address.
+
+- Set `DISCOURSE_HOSTNAME` to `discourse.example.com`, this means you want your Discourse available at `http://discourse.example.com/`. You'll need to update the DNS A record for this domain with the IP address of your server.
+
+- Place your mail credentials in `DISCOURSE_SMTP_ADDRESS`, `DISCOURSE_SMTP_PORT`, `DISCOURSE_SMTP_USER_NAME`, `DISCOURSE_SMTP_PASSWORD`. Be sure you remove the comment `#` character and space from the front of these lines as necessary.
+
+- If you are using a 1 GB instance, set `UNICORN_WORKERS` to 2 and `db_shared_buffers` to 128MB so you have more memory room.
+
+**Email is CRITICAL for account creation and notifications in Discourse. If you do not properly configure email before bootstrapping YOU WILL HAVE A BROKEN SITE!**
+
+Step 2: Create an ATLAS artifact
+---
+Store the complete infrastructure configuration and the deployment scripts as an ATLAS artifact using Packer.
+
+```
+{
+    "variables": {
+        "aws_access_key": "YOUR_ACCESS_KEY",
+        "aws_secret_key": "YOUR_SECRET_KEY"
+    },
+    "builders": [{
+        "type": "amazon-ebs",
+        "access_key": "{{user `aws_access_key`}}",
+        "secret_key": "{{user `aws_secret_key`}}",
+        "region": "us-east-1",
+        "source_ami": "ami-9a562df2",
+        "instance_type": "t2.micro",
+        "ssh_username": "ubuntu",
+        "ami_name": "discourse {{timestamp}}"
+    }],
+    "push": {
+      "name": "<username>/discourse"
+    },
+    "provisioners": [
+    {   
+        "type": "shell",
+        "inline": [
+            "sudo mkdir /ops",
+            "sudo chmod a+w /ops"
+        ]
+    },
+    {   
+        "type": "file",
+        "source": ".",
+        "destination": "/ops"
+    },
+    {
+        "type": "shell",
+        "scripts": [
+            "scripts/create_swap.sh",
+            "scripts/deploy.sh"
+        ]
+    }
+    ],
+    "post-processors": [
+      {
+        "type": "atlas",
+        "artifact": "<username>/discourse",
+        "artifact_type": "aws.ami",
+        "metadata": {
+          "created_at": "{{timestamp}}"
+        }
+      }
+    ]
+}
+```
+
+Run `packer push -create discourse-artifact.json` to build the ATLAS artifact.
+
+Step 3: Deploy Infratsructure on AWS
+---
+Deploy the complete infrastructure stored as an ATLAS artifact by running `terraform apply` in `ops/terraform` directory. Make sure to allow `tcp` traffic on port `80` in your security group. If you don't have, you can create one.
+
+```
+resource "aws_security_group" "allow_tcp" {
+  name = "allow_tcp"
+    description = "Allow tcp traffic on port 80"
+
+  ingress {
+      from_port = 80
+      to_port = 80
+      protocol = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_instance" "discourse" {
+    instance_type = "t2.micro"
+    ami = "${atlas_artifact.discourse.metadata_full.region-us-east-1}"
+    security_groups = ["${aws_security_group.allow_tcp.name}"]
+
+    # This will create 1 instance
+    count = 1
+    lifecycle = {
+      create_before_destroy = true
+    }
+}
+```
+
+Final Step: Register New Account and Become Admin
+--------------------------------
+1. Navigate to the Public IP of your Discourse forum. Run terraform show to easily find this information or alternatively navigate to the domain name you provided while configuring the DNS settings. You should see the default Discourse page.
+
+2. That's it! You just deployed a Discourse forum on AWS. For post install maintenance and more Discourse features see [official Discourse guide](https://github.com/discourse/discourse/blob/master/docs/INSTALL-digital-ocean.md).
+
+Troubleshooting/Debugging
+----
+For debugging puposes please see our [AWS-SSH-Setup guide](https://github.com/hashicorp/atlas-examples/tree/master/AWS-SSH-Setup).

--- a/Discourse/ops/configs/standalone.yml
+++ b/Discourse/ops/configs/standalone.yml
@@ -1,0 +1,99 @@
+##
+## After making changes to this file, you MUST rebuild for any changes
+## to take effect in your live Discourse instance:
+##
+## /var/discourse/launcher rebuild app
+##
+## Make sure to obey YAML syntax! You can use this site to help check:
+## http://www.yamllint.com/
+
+## this is the all-in-one, standalone Discourse Docker container template
+
+# You may add rate limiting by uncommenting the web.ratelimited template.
+# Out of the box it allows 12 reqs a second per ip, and 100 per minute per ip
+# This is configurable by amending the params in this file
+
+templates:
+  - "templates/postgres.template.yml"
+  - "templates/redis.template.yml"
+  - "templates/web.template.yml"
+  - "templates/sshd.template.yml"
+  - "templates/web.ratelimited.template.yml"
+
+## which TCP/IP ports should this container expose?
+expose:
+  - "80:80"   # fwd host port 80   to container port 80 (http)
+  - "2222:22" # fwd host port 2222 to container port 22 (ssh)
+
+params:
+  db_default_text_search_config: "pg_catalog.english"
+  ## Set db_shared_buffers to 1/3 of the memory you wish to allocate to postgres
+  ## on 1GB install set to 128MB on a 4GB instance you may raise to 1GB
+  #db_shared_buffers: "256MB"
+  #
+  ## Which Git revision should this container use? (default: tests-passed)
+  #version: tests-passed
+
+env:
+  LANG: en_US.UTF-8
+  # DISCOURSE_DEFAULT_LOCALE: en
+
+  ## TODO: How many concurrent web requests are supported?
+  ## With 2GB we recommend 3-4 workers, with 1GB only 2
+  #UNICORN_WORKERS: 3
+
+  ## TODO: List of comma delimited emails that will be made admin and developer
+  ## on initial signup example 'user1@example.com,user2@example.com'
+  DISCOURSE_DEVELOPER_EMAILS: 'me@example.com'
+
+  ## TODO: The domain name this Discourse instance will respond to
+  DISCOURSE_HOSTNAME: 'discourse.example.com'
+
+  ## TODO: The mailserver this Discourse instance will use
+  DISCOURSE_SMTP_ADDRESS: smtp.example.com         # (mandatory)
+  #DISCOURSE_SMTP_PORT: 587                        # (optional)
+  #DISCOURSE_SMTP_USER_NAME: user@example.com      # (optional)
+  #DISCOURSE_SMTP_PASSWORD: pa$$word               # (optional)
+  #DISCOURSE_SMTP_ENABLE_START_TLS: true           # (optional, default true)
+
+  ## The CDN address for this Discourse instance (configured to pull)
+  #DISCOURSE_CDN_URL: //discourse-cdn.example.com
+
+## These containers are stateless, all data is stored in /shared
+volumes:
+  - volume:
+      host: /var/discourse/shared/standalone
+      guest: /shared
+  - volume:
+      host: /var/discourse/shared/standalone/log/var-log
+      guest: /var/log
+
+## The docker manager plugin allows you to one-click upgrade Discourse
+## http://discourse.example.com/admin/docker
+hooks:
+  after_code:
+    - exec:
+        cd: $home/plugins
+        cmd:
+          - mkdir -p plugins
+          - git clone https://github.com/discourse/docker_manager.git
+
+## Remember, this is YAML syntax - you can only have one block with a name
+run:
+  - exec: echo "Beginning of custom commands"
+
+  ## If you want to set the 'From' email address for your first registration, uncomment and change:
+  #- exec: rails r "SiteSetting.notification_email='info@unconfigured.discourse.org'"
+  ## After getting the first signup email, re-comment the line. It only needs to run once.
+
+  ## If you want to configure password login for root, uncomment and change:
+  ## Use only one of the following lines:
+  #- exec: /usr/sbin/usermod -p 'PASSWORD_HASH' root
+  #- exec: /usr/sbin/usermod -p "$(mkpasswd -m sha-256 'RAW_PASSWORD')" root
+
+  ## If you want to authorized additional users, uncomment and change:
+  #- exec: ssh-import-id username
+  #- exec: ssh-import-id anotherusername
+
+  - exec: echo "End of custom commands"
+  - exec: awk -F\# '{print $1;}' ~/.ssh/authorized_keys | awk 'BEGIN { print "Authorized SSH keys for this container:"; } NF>=2 {print $NF;}'

--- a/Discourse/ops/discourse-artifact.json
+++ b/Discourse/ops/discourse-artifact.json
@@ -1,0 +1,50 @@
+{
+    "variables": {
+        "aws_access_key": "YOUR_ACCESS_KEY",
+        "aws_secret_key": "YOUR_SECRET_KEY"
+    },
+    "builders": [{
+        "type": "amazon-ebs",
+        "access_key": "{{user `aws_access_key`}}",
+        "secret_key": "{{user `aws_secret_key`}}",
+        "region": "us-east-1",
+        "source_ami": "ami-9a562df2",
+        "instance_type": "t2.micro",
+        "ssh_username": "ubuntu",
+        "ami_name": "discourse {{timestamp}}"
+    }],
+    "push": {
+      "name": "<username>/discourse"
+    },
+    "provisioners": [
+    {   
+        "type": "shell",
+        "inline": [
+            "sudo mkdir /ops",
+            "sudo chmod a+w /ops"
+        ]
+    },
+    {   
+        "type": "file",
+        "source": ".",
+        "destination": "/ops"
+    },
+    {
+        "type": "shell",
+        "scripts": [
+            "scripts/create_swap.sh",
+            "scripts/deploy.sh"
+        ]
+    }
+    ],
+    "post-processors": [
+      {
+        "type": "atlas",
+        "artifact": "<username>/discourse",
+        "artifact_type": "aws.ami",
+        "metadata": {
+          "created_at": "{{timestamp}}"
+        }
+      }
+    ]
+}

--- a/Discourse/ops/scripts/create_swap.sh
+++ b/Discourse/ops/scripts/create_swap.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+sudo install -o root -g root -m 0600 /dev/null /swapfile
+sudo dd if=/dev/zero of=/swapfile bs=1k count=2048k
+sudo mkswap /swapfile
+sudo swapon /swapfile
+echo "/swapfile       swap    swap    auto      0       0" | sudo tee -a /etc/fstab
+sudo sysctl -w vm.swappiness=10
+echo vm.swappiness = 10 | sudo tee -a /etc/sysctl.conf

--- a/Discourse/ops/scripts/deploy.sh
+++ b/Discourse/ops/scripts/deploy.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+sudo wget -qO- https://get.docker.io/ | sh
+sudo mkdir /var/discourse
+sudo git clone https://github.com/discourse/discourse_docker.git /var/discourse
+sudo cp /ops/configs/standalone.yml /var/discourse/containers/app.yml
+cd /var/discourse
+sudo ./launcher bootstrap app
+sudo ./launcher start app

--- a/Discourse/ops/terraform/discourse-infra.tf
+++ b/Discourse/ops/terraform/discourse-infra.tf
@@ -1,0 +1,34 @@
+provider "aws" {
+    access_key = "YOUR_ACCESS_KEY"
+    secret_key = "YOUR_SECRET_KEY"
+    region = "us-east-1"
+}
+
+resource "atlas_artifact" "discourse" {
+    name = "<username>/discourse"
+    type = "aws.ami"
+}
+
+resource "aws_security_group" "allow_tcp" {
+  name = "allow_tcp"
+    description = "Allow tcp traffic on port 80"
+
+  ingress {
+      from_port = 80
+      to_port = 80
+      protocol = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_instance" "discourse" {
+    instance_type = "t2.micro"
+    ami = "${atlas_artifact.discourse.metadata_full.region-us-east-1}"
+    security_groups = ["${aws_security_group.allow_tcp.name}"]
+
+    # This will create 1 instance
+    count = 1
+    lifecycle = {
+      create_before_destroy = true
+    }
+}


### PR DESCRIPTION
Added example to deploy Discourse on AWS using the officially supported Docker installation.

For easy review:  https://github.com/bitgeeky/atlas-examples/tree/discourse/Discourse
Deployed example: http://54.152.202.163/

Please review. @KFishner  r ?