### PR TITLE
artifacts: rename aws.ami to amazon.ami

### DIFF
--- a/HAProxy-Nodejs/packer/consul.json
+++ b/HAProxy-Nodejs/packer/consul.json
@@ -38,7 +38,7 @@
       {
         "type": "atlas",
         "artifact": "{{user `atlas_username`}}/consul",
-        "artifact_type": "aws.ami",
+        "artifact_type": "amazon.ami",
         "metadata": {
           "created_at": "{{timestamp}}"
         }

--- a/HAProxy-Nodejs/packer/haproxy.json
+++ b/HAProxy-Nodejs/packer/haproxy.json
@@ -57,7 +57,7 @@
       {
         "type": "atlas",
         "artifact": "{{user `atlas_username`}}/haproxy",
-        "artifact_type": "aws.ami",
+        "artifact_type": "amazon.ami",
         "metadata": {
           "created_at": "{{timestamp}}"
         }

--- a/HAProxy-Nodejs/packer/nodejs.json
+++ b/HAProxy-Nodejs/packer/nodejs.json
@@ -19,14 +19,14 @@
       "vcs": false
     },
     "provisioners": [
-    {   
+    {
         "type": "shell",
         "inline": [
             "sudo mkdir /application",
             "sudo chmod a+w /application"
         ]
     },
-    {   
+    {
         "type": "file",
         "source": "/packer/app",
         "destination": "/application"
@@ -59,7 +59,7 @@
       {
         "type": "atlas",
         "artifact": "{{user `atlas_username`}}/nodejs",
-        "artifact_type": "aws.ami",
+        "artifact_type": "amazon.ami",
         "metadata": {
           "created_at": "{{timestamp}}"
         }

--- a/HAProxy-Nodejs/terraform/main.tf
+++ b/HAProxy-Nodejs/terraform/main.tf
@@ -9,17 +9,17 @@ provider "aws" {
 //
 resource "atlas_artifact" "nodejs" {
   name = "${var.atlas_username}/nodejs"
-  type = "aws.ami"
+  type = "amazon.ami"
 }
 
 resource "atlas_artifact" "haproxy" {
   name = "${var.atlas_username}/haproxy"
-  type = "aws.ami"
+  type = "amazon.ami"
 }
 
 resource "atlas_artifact" "consul" {
   name = "${var.atlas_username}/consul"
-  type = "aws.ami"
+  type = "amazon.ami"
 }
 
 //

--- a/metamon/ops/consul.json
+++ b/metamon/ops/consul.json
@@ -51,7 +51,7 @@
       {
         "type": "atlas",
         "artifact": "YOUR_ATLAS_USERNAME/consul",
-        "artifact_type": "aws.ami",
+        "artifact_type": "amazon.ami",
         "metadata": {
           "created_at": "{{timestamp}}"
         }

--- a/metamon/ops/site.json
+++ b/metamon/ops/site.json
@@ -78,7 +78,7 @@
       {
         "type": "atlas",
         "artifact": "YOUR_ATLAS_USERNAME/metamon",
-        "artifact_type": "aws.ami",
+        "artifact_type": "amazon.ami",
         "metadata": {
           "created_at": "{{timestamp}}"
         }

--- a/metamon/ops/terraform/main.tf
+++ b/metamon/ops/terraform/main.tf
@@ -10,12 +10,12 @@ provider "aws" {
 
 resource "atlas_artifact" "metamon" {
     name = "${var.atlas_username}/metamon"
-    type = "aws.ami"
+    type = "amazon.ami"
 }
 
 resource "atlas_artifact" "consul" {
     name = "${var.atlas_username}/consul"
-    type = "aws.ami"
+    type = "amazon.ami"
 }
 
 resource "aws_vpc" "main" {


### PR DESCRIPTION
This is more consistent with our current documentation
on Atlas, Terraform and Packer.