### PR TITLE
Fixed haproxy build success when install failed

### DIFF
--- a/HAProxy-Nodejs/packer/scripts/haproxy.sh
+++ b/HAProxy-Nodejs/packer/scripts/haproxy.sh
@@ -1,3 +1,6 @@
+# exit on exception
+set -e
+
 # install HAproxy
 sudo apt-get install -y haproxy
 sudo chmod a+w /etc/rsyslog.conf


### PR DESCRIPTION
Occassionally haproxy will fail to install correctly but the build will still succeed. I added "set -e" so the script will exit on any statement that returns a non true return value.