### PR TITLE
Use var for IAM Role Name and Update Instructions

### DIFF
--- a/codedeploy-consul/README.md
+++ b/codedeploy-consul/README.md
@@ -38,7 +38,7 @@ application are healthy in Consul's service catalog
   $ export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
   $ export AWS_DEFAULT_REGION=us-east-1
   ```
-2. Create an S3 bucket for application files.
+2. Create an S3 bucket for application files.  The bucket should be created in the same region you will create the CodeDeploy application.
 
   > The S3 bucket is not managed by Terraform because S3 buckets cannot be
   created, destroyed, and recreated quickly without

--- a/codedeploy-consul/terraform/iam.tf
+++ b/codedeploy-consul/terraform/iam.tf
@@ -2,7 +2,7 @@
 // Service role for CodeDeploy service
 //
 resource "aws_iam_role" "codedeploy_service_role" {
-  name = "CodeDeployServiceRole"
+  name = "${var.codedeploy_iam_role_name}"
   assume_role_policy = "${file("${module.shared.path}/codedeploy-agent/iam/CodeDeployDemo-Trust.json")}"
 }
 

--- a/codedeploy-consul/terraform/main.tf
+++ b/codedeploy-consul/terraform/main.tf
@@ -34,6 +34,9 @@ variable "vpc_cidrs" { default = "172.31.0.0/20,172.31.16.0/20,172.31.32.0/20" }
 
 variable "consul_bootstrap_expect" { default = "3" }
 variable "consul_ui_access_cidr"   { default = "172.31.0.0/16" }
+variable "codedeploy_iam_role_name" {
+  default = "DemoCodeDeployServiceRole"
+}
 
 //
 // Outputs
@@ -51,6 +54,12 @@ To deploy a new version of the application:
      deployment group name shown below:
 
         CodeDeploy Deployment Group Name: ${aws_codedeploy_deployment_group.sampleapp.deployment_group_name}
+
+     You will also need to specify a CodeDeploy Deployment config.  Example:
+
+        --deployment-config-name CodeDeployDefault.AllAtOnce
+
+     A deployment description is optional.
 
   3) Monitor the deployment using the Deployment Id returned by the
      `aws deploy create-deployment` command:


### PR DESCRIPTION
Greetings from AWS!  I ran through the example and just added a couple minor things.

1. If the user has already ran through the Getting Started wizard they will likely already have an IAM Role named CodeDeployServiceRole which will prevent Terraform from creating it.  Suggesting to change the IAM Role name to a variable.

2.  Update the README to mention that the S3 Bucket should be created in the same region as the CodeDeploy application and rest of the infrastructure.  CodeDeploy will fail during the deploy step if the bucket is in another region.

3.  Suggest adding in the instructions output an example CodeDeploy Deployment config option as this is a required option for the deploy step.  Also added a minor note that the description field is optional.

Thanks :)