### PR TITLE
Use security group name and not ID

### DIFF
--- a/setup/ssh.md
+++ b/setup/ssh.md
@@ -49,7 +49,7 @@ resource "aws_instance" "app_server" {
   count = 1
   ami = "ami-408c7f28"
   instance_type = "t1.micro"
-  security_groups = ["${aws_security_group.allow_ssh.id}"]
+  security_groups = ["${aws_security_group.allow_ssh.name}"]
   key_name = "${aws_key_pair.debugging.key_name}"
 }
 ```


### PR DESCRIPTION
## Problem

Using the provided code I receive the following error when executing the plan:

```
Error: Error applying plan:

1 error(s) occurred:

* aws_instance.example: 1 error(s) occurred:

* aws_instance.example: Error launching instance, possible mismatch of Security Group IDs and Names. See AWS Instance docs here: https://terraform.io/docs/providers/aws/r/instance.html.

	AWS Error: Value () for parameter groupId is invalid. The value cannot be empty
```

## Solution

I googled a bit and found someone else running into a similar issue (https://github.com/mitchellh/vagrant-aws/issues/459). They fixed it by using the `name` instead of the `id` parameter. When I try the same, the plan succeeds.